### PR TITLE
[review] Use CharacterSet's toHexRangeString to format the --unicodes output.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "chalk": "^1.1.3",
-    "characterset": "^1.1.3",
+    "characterset": "^1.2.0",
     "minimist": "^1.2.0",
     "phantomjs-prebuilt": "^2.1.14",
     "rsvp": "^3.3.3"

--- a/phantomjs-glyphhanger.js
+++ b/phantomjs-glyphhanger.js
@@ -87,9 +87,7 @@ Rsvp.all( promises ).then( function( results ) {
 	}
 
 	if( isCodePoints ) {
-		console.log( combinedCharacterSet.toArray().map(function( code ) {
-				return 'U+' + code.toString(16);
-			}).join(',') );
+		console.log( combinedCharacterSet.toHexRangeString() );
 	} else {
 		console.log( combinedCharacterSet.toArray().map(function( code ) {
 				return String.fromCharCode( code );


### PR DESCRIPTION
This changes the code to use CharacterSet's `toHexRangeString` to format the `--unicodes` output. This function uses CharacterSet's internal functions to output both individual code points and ranges:

```
$ glyphhanger http://example.com --unicodes
U+A,U+20,U+2E,U+44,U+45,U+4D,U+54,U+59,U+61-69,U+6B-70,U+72-79
```