### PR TITLE
Fixes missing dependencies, adds initial CLI test

### DIFF
--- a/src/GlyphHangerSubset.js
+++ b/src/GlyphHangerSubset.js
@@ -2,6 +2,8 @@ var shell = require( "shelljs" );
 var parsePath = require( "parse-filepath" );
 var fs = require( "fs" );
 var filesize = require( "filesize" );
+var path = require( "path" );
+var chalk = require( "chalk" );
 
 function GlyphHangerSubset() {}
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,13 +1,26 @@
-const assert = require( "assert" );
-const path = require( "path" );
-const childProcess = require( "child_process" );
+var assert = require( "assert" );
+var path = require( "path" );
+var childProcess = require( "child_process" );
+var fs = require( "fs" );
+
+var fontPath = "test/fonts/sourcesanspro-regular.ttf"
+
+var removeFile = function( filePath ) {
+	fs.unlinkSync( filePath );
+}
 
 describe( "glyphhanger cli", function() {
-
-	it( "Produced a file", function (done) {
-		childProcess.exec('node index.js --whitelist=ABC --subset=test/fonts/sourcesanspro-regular.ttf', function(err) {
-      if (err) done(err)
-      else done();
+	it( "Produced a file", function ( done ) {
+		childProcess.exec(`node index.js --whitelist=ABC --subset=${fontPath} --formats=ttf`, function(err) {
+      if ( err ) {
+				done( err );
+			} else {
+				var subsetPath = fontPath.split( ".ttf" ).join( "-subset.ttf" )
+				var subset = fs.existsSync( subsetPath );
+				assert.ok( subset );
+				removeFile( subsetPath );
+				done();
+			};
 		})
 	})
 });

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,13 @@
+const assert = require( "assert" );
+const path = require( "path" );
+const childProcess = require( "child_process" );
+
+describe( "glyphhanger cli", function() {
+
+	it( "Produced a file", function (done) {
+		childProcess.exec('node index.js --whitelist=ABC --subset=test/fonts/sourcesanspro-regular.ttf', function(err) {
+      if (err) done(err)
+      else done();
+		})
+	})
+});


### PR DESCRIPTION
`path` and `chalk` were missing from GlyphHangerSubset when using the CLI, so I fixed that and added the beginnings of CLI tests.

To give it a try, checkout the branch and run:

```sh
npm test -- test/cli.js
```

This uses `exec` to run `glyphhanger` as a CLI tool, generates a subset of Source Sans Pro, and then cleans up the subset file.

I tried to do something fairly basic that wouldn’t introduce another dev dependency, but if you have a different approach you like, feel free to let me know. Also happy to move it back into the `test.js` file if you want.