### PR TITLE
fixed SITE_PATH in WebServer.js that is previously incorrect

### DIFF
--- a/src/WebServer.js
+++ b/src/WebServer.js
@@ -4,7 +4,7 @@ const path = require( "path" );
 const { URL } = require("url");
 const debug = require("debug")("glyphhanger:webserver");
 
-const SITE_PATH = path.resolve(__dirname, "..");
+const SITE_PATH = path.resolve(process.cwd(), ".");
 const SERVER_PORT = 8093;
 
 class WebServer {


### PR DESCRIPTION
Previously, the code used `__dirname` for WebServer's root path, but `__dirname` by definition returns the directory name of the directory containing the JavaScript source code file, that usually is `/usr/local/lib/node_modules/glyphhanger/src` or something like that.

`process.cwd()` returns the current working directory,  i.e. the directory from which you invoked the `node` command, and this directory is the path the WebServer should use it as the `SITE_PATH`.

As a ref, I found this error: 

➜  fontSubsetInAction glyphhanger ./local.txt --string
(node:20934) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: Evaluation failed: Event
(node:20934) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.