### PR TITLE
Adds `--output` to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ Writing CSS file: LatoLatin-Regular.css
 }
 ```
 
+#### Specify output directory for any files created with `--output`
+
+```sh
+> glyphhanger --subset=*.ttf --output=some/other/path
+
+Subsetting LatoLatin-Regular.ttf to LatoLatin-Regular-subset.woff (was 145.06 KB, now 2.88 KB)
+Subsetting LatoLatin-Regular.ttf to LatoLatin-Regular-subset.woff2 (was 145.06 KB, now 2.24 KB)
+```
+
 ### Whitelist Characters
 
 ```sh


### PR DESCRIPTION
It's not much, but it's something :3rd_place_medal: 

One thing though, maybe include the new path in the output, eg:
```sh
> glyphhanger --subset=*.ttf --output=some/other/path

Subsetting LatoLatin-Regular.ttf to some/other/path/LatoLatin-Regular-subset.woff (was 145.06 KB, now 2.88 KB)
Subsetting LatoLatin-Regular.ttf to some/other/path/LatoLatin-Regular-subset.woff2 (was 145.06 KB, now 2.24 KB)
```

.. great software, thank you very much!